### PR TITLE
python-xbox library needs to be at least 0.1.3, as that introduced a fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license-files = ["LICEN[CS]E*"]
 authors = [{ name = "Michal Szymanski", email = "misiektoja-pypi@rm-rf.ninja" }]
 requires-python = ">=3.8"
 dependencies = [
-  "python-xbox>=1.0.0",
+  "python-xbox>=0.1.3",
   "requests>=2.0",
   "python-dateutil>=2.8",
   "httpx>=0.26.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-xbox
+python-xbox>=0.1.3
 requests
 python-dateutil
 httpx


### PR DESCRIPTION
I noticed this because I was having the same issue because my python-xbox was 0.1.2 and not updating or being flagged by the requirements.txt

Does pyproject.toml need to change? I'm not sure how that works, but currently it has >= 1.0.0, which doesn't exist:
`python-xbox>=1.0.0`